### PR TITLE
Changed landing css carousel

### DIFF
--- a/src/main/resources/static/css/landing.css
+++ b/src/main/resources/static/css/landing.css
@@ -10,8 +10,8 @@
 }
 
 .carousel-caption {
-    top: 90%;
-    transform: translateY(-90%);
+    top: 75%;
+    transform: translateY(-75%);
     bottom: initial;
 }
 


### PR DESCRIPTION
Landing page carosuel was unreadable because the pictures light
background and the carousel item caption's light font didn't go
well together.
CSS change made the caption go higher.