### PR TITLE
Removed unused antMatcher pattern

### DIFF
--- a/src/main/java/com/deiksoftdev/automatagame/security/SecurityConfig.java
+++ b/src/main/java/com/deiksoftdev/automatagame/security/SecurityConfig.java
@@ -35,7 +35,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/index").permitAll()
                 .antMatchers("/register").permitAll()
                 .antMatchers("/login").permitAll()
-                .antMatchers("/user/**").hasRole("USER")
                 .anyRequest().authenticated()
                 .and()
                 .formLogin().loginPage("/login")


### PR DESCRIPTION
This antmatcher pattern was left in due to my human error(introduced in the security update branch).
It is not needed, because we're not supporting currently requests made against /user/**.
I deleted it because it was just confusing.