### PR TITLE
Issue20 roles security

### DIFF
--- a/src/main/java/com/deiksoftdev/automatagame/register/UserRegisterService.java
+++ b/src/main/java/com/deiksoftdev/automatagame/register/UserRegisterService.java
@@ -34,6 +34,7 @@ public class UserRegisterService {
         user.setName(userRegisterDTO.getName());
         user.setPassword(passwordEncoder.encode(userRegisterDTO.getPassword()));
         user.setEmail(userRegisterDTO.getEmail());
+        user.setAdmin(false);
         user = userRepository.save(user);
         return user;
     }

--- a/src/main/java/com/deiksoftdev/automatagame/security/CustomUserDetails.java
+++ b/src/main/java/com/deiksoftdev/automatagame/security/CustomUserDetails.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.LinkedList;
 
 @Data
 @AllArgsConstructor
@@ -18,7 +18,12 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.<GrantedAuthority>singletonList(new SimpleGrantedAuthority("User"));
+        var authorities = new LinkedList<SimpleGrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        if (user.isAdmin()) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        }
+        return authorities;
     }
 
     @Override
@@ -48,6 +53,6 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return !user.isDisabled();
     }
 }

--- a/src/main/java/com/deiksoftdev/automatagame/security/SecurityDataPreloader.java
+++ b/src/main/java/com/deiksoftdev/automatagame/security/SecurityDataPreloader.java
@@ -1,0 +1,54 @@
+package com.deiksoftdev.automatagame.security;
+
+import com.deiksoftdev.automatagame.user.User;
+import com.deiksoftdev.automatagame.user.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * This is a short lived class until a standalone db will be in place.
+ */
+@Component
+public class SecurityDataPreloader implements ApplicationListener<ContextRefreshedEvent> {
+
+    boolean alreadySetup = false;
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public SecurityDataPreloader(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    @Transactional
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        if (alreadySetup) {
+            return;
+        }
+        getUserCreateIfAbsent("user", "user@user.com", "user", false);
+        getUserCreateIfAbsent("admin", "admin@admin.com", "admin", true);
+        alreadySetup = true;
+    }
+
+    @Transactional
+    User getUserCreateIfAbsent(String name, String email, String password, boolean isAdmin) {
+        var user = userRepository.findByName(name);
+        if (user == null) {
+            user = new User();
+            user.setName(name);
+            user.setEmail(email);
+            user.setPassword(passwordEncoder.encode(password));
+            user.setAdmin(isAdmin);
+            return userRepository.save(user);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/deiksoftdev/automatagame/user/User.java
+++ b/src/main/java/com/deiksoftdev/automatagame/user/User.java
@@ -8,10 +8,10 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
-@AllArgsConstructor
-@NoArgsConstructor
 @Data
 @Entity
+@AllArgsConstructor
+@NoArgsConstructor
 public class User {
 
 	@Id
@@ -29,4 +29,10 @@ public class User {
 	@NotBlank(message = "Password is required")
 	@Column(nullable = false)
 	private String password;
+
+	@Column
+	private boolean admin;
+
+	@Column
+	private boolean disabled;
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head>
     <meta charset="UTF-8">
@@ -51,6 +51,13 @@
         <div class="container">
             <h1 class="display-3">Hello, Unity!</h1>
             <p>This is a placeholder for a given user's home page.</p>
+            <div sec:authorize="hasRole('USER')">Visible to user.</div>
+            <div sec:authorize="hasRole('ADMIN')">Visible to admin.</div>
+            <div sec:authorize="isAuthenticated()">Visible to authenticated.</div>
+            <div>
+                <span sec:authentication="principal.authorities">[]</span>
+                <div th:text="${#authentication.getName()}"></div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Röviden

- Mostmár a **_home_** lapon attól függően hogy _USER_ vagy _ADMIN_ vagy mást látsz.
- Mikor a szerver elindul létrehoz egy user-t és egy admin-t (rövid távú megoldás amíg nem rakunk alá standalone db-t).
- Nem akartam hogy valós törlés legyen ezért van egy új field-je a User-nek, amivel beállítható hogy disabled legyen

Mivel elég sok issue elkezdését blokkolja ha nincs meg ezért reviewer nélkül bemerge-ölöm.
Ez tényleg csúnya dolog, de meg kell csinálnom a többit issue odáig, hogy mások elkezdhessenek velük dolgozni.
(Magyarul pl. csinálok egy wonky és csúnya admin user listázó lapot, user disable service-t stb., és akkor a többieknek már csak ezeket kell csinosítani, vagy esetleg bekötni linkekkel stb.)

Close #20 